### PR TITLE
Add line number extraction for failed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@ The test object in the report includes the following [CTRF properties](https://c
 | `filepath`  | String  | Optional | The file path where the test is located in the project.                             |
 | `retries`   | Number  | Optional | The number of retries attempted for the test.                                       |
 | `flaky`     | Boolean | Optional | Indicates whether the test result is flaky.                                         |
+| `line`      | Number  | Optional | Line number in the source file if the test failed.                                  |

--- a/types/ctrf.d.ts
+++ b/types/ctrf.d.ts
@@ -36,6 +36,7 @@ export interface CtrfTest {
   tags?: string[]
   type?: string
   filePath?: string
+  line?: number
   retries?: number
   flaky?: boolean
   attempts?: CtrfTest[]


### PR DESCRIPTION
See: https://ctrf.io/docs/specification/test
 - Extract line numbers from stack traces and include in test reports
 - Add line property to CtrfTest interface and README documentation
 - Add lightweight regex-based stack trace parser

