### PR TITLE
feat: Add line number extraction for failed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@ The test object in the report includes the following [CTRF properties](https://c
 | `filepath`  | String  | Optional | The file path where the test is located in the project.                             |
 | `retries`   | Number  | Optional | The number of retries attempted for the test.                                       |
 | `flaky`     | Boolean | Optional | Indicates whether the test result is flaky.                                         |
+| `line`      | Number  | Optional | Line number in the source file if the test failed.                                  |

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -148,70 +148,81 @@ class GenerateCtrfReport implements Reporter {
 
   extractFailureDetails(testCase: TestCase): Partial<CtrfTest> {
     const testResult = testCase.result()
-    
+
     if (isTestFailed(testResult)) {
       const failureDetails: Partial<CtrfTest> = {}
       failureDetails.message = testResult.errors
         .map((error) => error.message)
         .join('\n')
-      
+
       const trace = testResult.errors
         .map((error) => error.stack)
         .filter(Boolean)
         .join('\n\n')
-      
+
       failureDetails.trace = trace
-      
+
       // Extract line number from stack trace for failed tests
       if (trace && testCase.module.moduleId) {
-        const lineNumber = this.extractLineNumber(trace, testCase.module.moduleId)
+        const lineNumber = this.extractLineNumber(
+          trace,
+          testCase.module.moduleId
+        )
         if (lineNumber !== undefined) {
           failureDetails.line = lineNumber
         }
       }
-      
+
       return failureDetails
     }
     return {}
   }
 
-  private parseStackTrace(stackString: string): Array<{file: string | null, lineNumber: number | null}> {
+  private parseStackTrace(
+    stackString: string
+  ): Array<{ file: string | null; lineNumber: number | null }> {
     // Node.js stack trace regex pattern from stacktrace-parser library
     // https://github.com/errwischt/stacktrace-parser
-    const nodeRe = /^\s*at (?:((?:\[object object\])?[^\\/]+(?: \[as \S+\])?) )?\(?(.*?):(\d+)(?::(\d+))?\)?\s*$/i
+    const nodeRe =
+      /^\s*at (?:((?:\[object object\])?[^\\/]+(?: \[as \S+\])?) )?\(?(.*?):(\d+)(?::(\d+))?\)?\s*$/i
     const lines = stackString.split('\n')
-    
-    return lines.reduce<Array<{file: string | null, lineNumber: number | null}>>((stack, line) => {
+
+    return lines.reduce<
+      Array<{ file: string | null; lineNumber: number | null }>
+    >((stack, line) => {
       const parts = nodeRe.exec(line)
-      
+
       if (parts) {
         stack.push({
           file: parts[2] || null,
-          lineNumber: parts[3] ? +parts[3] : null
+          lineNumber: parts[3] ? +parts[3] : null,
         })
       }
-      
+
       return stack
     }, [])
   }
 
-  private extractLineNumber(trace: string, testFilePath: string): number | undefined {
+  private extractLineNumber(
+    trace: string,
+    testFilePath: string
+  ): number | undefined {
     try {
       const stackFrames = this.parseStackTrace(trace)
-      
+
       // Find the first stack frame that matches the test file path
-      const testFrame = stackFrames.find(frame => {
+      const testFrame = stackFrames.find((frame) => {
         if (!frame.file) {
           return false
         }
-        
+
         // Normalize paths for comparison
         const normalizedFrameFile = path.resolve(frame.file)
         const normalizedTestFile = path.resolve(testFilePath)
-        
+
         return normalizedFrameFile === normalizedTestFile
       })
-      
+
       return testFrame?.lineNumber ?? undefined
     } catch {
       // Gracefully handle parsing errors

--- a/types/ctrf.d.ts
+++ b/types/ctrf.d.ts
@@ -36,6 +36,7 @@ export interface CtrfTest {
   tags?: string[]
   type?: string
   filePath?: string
+  line?: number
   retries?: number
   flaky?: boolean
   attempts?: CtrfTest[]


### PR DESCRIPTION
See: https://ctrf.io/docs/specification/test
 - Extract line numbers from stack traces and include in test reports
 - Add line property to CtrfTest interface and README documentation
 - Add lightweight regex-based stack trace parser